### PR TITLE
Feedback + physical parameters added

### DIFF
--- a/tutorial/linking/spheres/linking_spheres.ipynb
+++ b/tutorial/linking/spheres/linking_spheres.ipynb
@@ -94,11 +94,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "id": "WadH3picQOZT"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "ename": "ModuleNotFoundError",
+          "evalue": "No module named 'matplotlib'",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[1;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+            "Cell \u001b[1;32mIn[1], line 8\u001b[0m\n\u001b[0;32m      5\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mlogging\u001b[39;00m\n\u001b[0;32m      7\u001b[0m \u001b[38;5;66;03m# Configuration\u001b[39;00m\n\u001b[1;32m----> 8\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mmatplotlib\u001b[39;00m\n\u001b[0;32m      9\u001b[0m matplotlib\u001b[38;5;241m.\u001b[39mrcParams[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124manimation.embed_limit\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m60\u001b[39m \u001b[38;5;66;03m# Allow larger animations inline\u001b[39;00m\n\u001b[0;32m     10\u001b[0m logging\u001b[38;5;241m.\u001b[39mdisable(logging\u001b[38;5;241m.\u001b[39mWARNING) \u001b[38;5;66;03m# Suppress warnings and below\u001b[39;00m\n",
+            "\u001b[1;31mModuleNotFoundError\u001b[0m: No module named 'matplotlib'"
+          ]
+        }
+      ],
       "source": [
         "# Standard libraries.\n",
         "import os\n",
@@ -2169,7 +2181,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "deeplay_env",
+      "display_name": "Python 3",
       "language": "python",
       "name": "python3"
     },
@@ -2183,7 +2195,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.10.9"
+      "version": "3.9.13"
     },
     "widgets": {
       "application/vnd.jupyter.widget-state+json": {

--- a/tutorial/linking/spheres/linking_spheres.ipynb
+++ b/tutorial/linking/spheres/linking_spheres.ipynb
@@ -233,7 +233,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Display the first frame of the video, manually select and display a single particle by specifying its centroid coordinates (x,y) and a box width."
+        "Display the first frame of the video, manually select and display a single particle by specifying its centroid coordinates (x, y) and a box width."
       ]
     },
     {
@@ -247,15 +247,36 @@
         "\n",
         "# Get the shape of the image.\n",
         "assert exp_image.shape[0] == exp_image.shape[1], \"Warning: Image is not square!\"\n",
-        "exp_image_size = exp_image.shape[0]\n",
-        "\n",
+        "exp_image_size = exp_image.shape[0]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Specify the parameters for the viewing box."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
         "# Box size to zoom in an individual particle.\n",
         "exp_crop_size = 15\n",
         "\n",
         "# Coordinates of the center of the particle.\n",
         "x_center = 96\n",
-        "y_center = 41\n",
-        "\n",
+        "y_center = 41"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
         "# Calculate top-left corner of the crop.\n",
         "x = x_center - exp_crop_size // 2\n",
         "y = y_center - exp_crop_size // 2\n",
@@ -1259,7 +1280,7 @@
         "# Link detections across frames into trajectories using trackpy.link().\n",
         "exp_trajs_pred_method1 = tp.link(\n",
         "    df_exp_video,\n",
-        "    search_range=20,\n",
+        "    search_range=20, \n",
         "    memory=3,\n",
         ")\n",
         "\n",
@@ -1856,7 +1877,7 @@
         "id": "wh6ldS5tQOZn"
       },
       "source": [
-        "### Linking Localizations in Experiments"
+        "### Linking Localizations in Simulations"
       ]
     },
     {

--- a/tutorial/utils/utils_datagen.py
+++ b/tutorial/utils/utils_datagen.py
@@ -232,7 +232,7 @@ def transform_to_video(
     # Sequential definition of particles with changing positions per frame.
     sequential_inner_particle = dt.Sequential(
         inner_particle,
-        position=lambda trajectory, sequence_step: trajectory[sequence_step],
+        position=lambda trajectory, sequence_index: trajectory[sequence_index],
     )
 
 #   Check if shell particle properties are provided.
@@ -253,7 +253,7 @@ def transform_to_video(
 
         sequential_outer_particle = dt.Sequential(
             outer_particle,
-            position=lambda trajectory, sequence_step: trajectory[sequence_step],
+            position=lambda trajectory, sequence_index: trajectory[sequence_index],
         )
 
         combined_particle = (


### PR DESCRIPTION
Since newer versions of deeptrack uses `sequence_index` instead of `sequence_step` for `SequentialProperties`, we should keep this in mind since the utils file utilizes this class.